### PR TITLE
Fix double callback on callee throw

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,19 +133,28 @@ function HTTPTransportClient (config) {
       res.on('data', function (data) {
         response += data;
       });
+      let hasCalledCallback = false;
+      function finish (err, data) {
+        if (hasCalledCallback) {
+          // do nothing
+          return;
+        }
+        hasCalledCallback = true;
+        return callback(err, data);
+      }
       res.on('end', function () {
         try {
           if (!response || response === 'undefined') {
-            return callback();
+            return finish();
           }
           var parsedJSON = JSON.parse(response);
           if (parsedJSON.$htTransportError) {
-            return callback(parsedJSON.$htTransportError);
+            return finish(parsedJSON.$htTransportError);
           }
-          return callback(null, parsedJSON);
+          return finish(null, parsedJSON);
         } catch (e) {
           // Return response here anyway
-          return callback(utils.formatError(response).error);
+          return finish(utils.formatError(response).error);
         }
       });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -459,5 +459,39 @@ describe('HTTP Transport', function () {
         });
       });
     });
+    it('should not call callback twice if callee throws from callback function', function (done) {
+      this.timeout(1000);
+      let app = express();
+      app.use(bodyParser.json());
+      app.post('/ht', function (req, res) {
+        res.json({
+          data: req.body
+        });
+      });
+
+      let called = 0;
+
+      let client = new transport.Client();
+
+      let _server = app.listen(port, host, function () {
+        setTimeout(function () {
+          if (called > 1) {
+            throw new Error('client callback called more than once');
+          }
+          return _server.close(done);
+        }, 800);
+        client.call('method', {
+          hello: 'world'
+        }, function (err, response) {
+          if (err) {
+            // ignore here
+          }
+          called++;
+          if (called < 2) {
+            throw new Error('unwind stack');
+          }
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
When you call `transport.call` and pass in a callback, this transport will then do its stuff, and call that callback. If that callback then throws (back in **your** code!) it will unwind the stack back into `transport.call` where there is a `try/catch` waiting, and the catch also calls `callback` - leading to a double callback. 
