### PR TITLE
Fix double callback on throw

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,14 +139,14 @@ function HTTPTransportClient (config) {
             return callback();
           }
           var parsedJSON = JSON.parse(response);
-          if (parsedJSON.$htTransportError) {
-            return callback(parsedJSON.$htTransportError);
-          }
-          return callback(null, parsedJSON);
         } catch (e) {
           // Return response here anyway
           return callback(utils.formatError(response).error);
         }
+        if (parsedJSON.$htTransportError) {
+          return callback(parsedJSON.$htTransportError);
+        }
+        return callback(null, parsedJSON);
       });
     });
 


### PR DESCRIPTION
See #2 for context, I think this is the correct solution.

Not sure how I can make this test pass, as we need it to throw to unwind the stack, to make sure we can't end up back in Transport territory, but mocha catches that, and fails the test, as we can't handle it. Open to suggestions.
