### PR TITLE
Bugfix: Cannot read property of null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,7 @@ function HTTPTransportClient (config) {
           // Return response here anyway
           return callback(utils.formatError(response).error);
         }
-        if (parsedJSON.$htTransportError) {
+        if (parsedJSON && parsedJSON.$htTransportError) {
           return callback(parsedJSON.$htTransportError);
         }
         return callback(null, parsedJSON);


### PR DESCRIPTION
fixed `TypeError: Cannot read property '$htTransportError' of null `