### PR TITLE
Add agent & timeout options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,8 @@ function HTTPTransportClient (config) {
       port: this.config.port,
       path: this.config.path,
       method: 'POST',
+      agent: this.config.agent,
+      timeout: this.config.timeout,
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': new Buffer(json).length


### PR DESCRIPTION
This will provides more options such as enabling `keep-alive` connection through `httpAgent` and setting timeout on http requests.
  
[Http interface document](https://nodejs.org/api/http.html#http_http_request_options_callback)