### PR TITLE
Improves handling of request timeout

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -415,6 +415,51 @@ describe('HTTP Transport', function () {
       });
     });
 
+    it('should timeout if server does not respond in time', function (done) {
+      this.timeout(2000);
+      const app = express();
+      app.post('/ht', function (req, res) {
+      });
+
+      const transport = new HTTP({
+        port,
+        host,
+        timeout: 1000
+      });
+      const client = new transport.Client();
+
+      const _app = app.listen(port, host, function () {
+        client.call('', {}, function (err) {
+          assert.equal(err, 'Timeout of 1000ms exceeded');
+          _app.close(done);
+        });
+      });
+    });
+
+    it('should not timeout when server responds in time', function (done) {
+      this.timeout(2000);
+      let _response = { something: 'world' };
+      const app = express();
+      app.post('/ht', function (req, res) {
+        res.send(_response);
+      });
+
+      const transport = new HTTP({
+        port,
+        host,
+        timeout: 1000
+      });
+      const client = new transport.Client();
+
+      const _app = app.listen(port, host, function () {
+        client.call('', {}, function (err, response) {
+          assert.equal(err, undefined);
+          assert.notStrictEqual(response, _response);
+          _app.close(done);
+        });
+      });
+    });
+
     it('should enable HTTPS if SSL options are specified', function (done) {
       let _method = 'hello';
       let _data = { something: 'world' };


### PR DESCRIPTION
According to the [docs](https://nodejs.org/api/http.html#http_http_request_url_options_callback) the `timeout` specified on the `request config` only occurs before socket connection is established. However if the server takes longer than the requested timeout to respond, `ht client` will keep waiting and no timeout will occur.

This PR attempts to improve the timeout handling by utilising `setTimeout` to abort a request irregardless if the cause of the timeout is dns lookup or backend latency.

This solution is mainly inspired by [Axios implementation](https://github.com/axios/axios/blob/75c8b3f146aaa8a71f7dca0263686fb1799f8f31/lib/adapters/http.js#L249)